### PR TITLE
bugfix:boundary error in _load_video

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "master"
+  pull_request:
+
 jobs:
   unittest:
     name: Unittest

--- a/src/marlin_pytorch/model/marlin.py
+++ b/src/marlin_pytorch/model/marlin.py
@@ -157,7 +157,7 @@ class Marlin(Module):
             v = padding_video(video, self.clip_frames, "same")  # (T, C, H, W)
             assert v.shape[0] == self.clip_frames
             yield v.permute(1, 0, 2, 3).unsqueeze(0).to(self.device)
-        elif total_frames < self.clip_frames * sample_rate:
+        elif total_frames <= self.clip_frames * sample_rate:
             video = read_video(video_path, channel_first=True) / 255  # (T, C, H, W)
             # use first 16 frames
             v = video[:self.clip_frames]


### PR DESCRIPTION
(1)
There is a boundary error in marlin_pytorch.marlin.py _line 160_. 
When the `total_frames=self.clip_frames * sample_rate`(in the default setting, it is `total_frames=32`, the program would turn into _line 167_ extracting features based on a sliding window, resulting in errors.
(2)
`ffmpeg.probe` gets more total frames than `read_video` implemented by `torchvision.io.read_video`, resulting in errors in the next condition choosing.
 